### PR TITLE
update arduino_image_provider to include Arduino.h

### DIFF
--- a/projects/portenta_person_detection/person_detection/arduino_image_provider.cpp
+++ b/projects/portenta_person_detection/person_detection/arduino_image_provider.cpp
@@ -7,7 +7,7 @@
 
 #include <string.h>
 
-#include "mbed.h"           // mbed library header - should be included by camera.h in the Arduino Portenta_Camera library instead
+#include "Arduino.h"        // required for use of camera.h in .cpp file
 #include "camera.h"         // header for the CameraClass class
 #include "image_provider.h" // the interface that is implemented here
 


### PR DESCRIPTION
Update portenta_person_detection/person_detection/arduino_image_provider.cpp
to include Arduino.h instead of mbed.h

Note that there was a PR to include Arduino.h in the Arduino library's camera.h,
making this include unneccessary, but that PR was rejected due to the increase
in compilation time it introduced for the Arduino library.

This PR is by an employee of Chariot Solutions, on behalf of ARM